### PR TITLE
'AUX' is reserved on Windows

### DIFF
--- a/src/hocs/Aux.js
+++ b/src/hocs/Aux.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const aux => props => props.children;
-
-export default aux;

--- a/src/hocs/Wrap.js
+++ b/src/hocs/Wrap.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const wrap => props => props.children;
+
+export default wrap;


### PR DESCRIPTION
Rename helper to 'Wrap' due to constraints on windows file naming.  // 'AUX' CAUSES MAJOR FS ISSUES